### PR TITLE
Fix rubocop warning for contacts controller

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,23 +1,22 @@
+# frozen_string_literal: true
+
+# Contacts Controller
 class ContactsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_area_backend
+  before_action :authorize_contact_policy
   after_action :verify_authorized
 
   # GET /examples or /examples.json
-
   def index
-    authorize nil, policy_class: ContactPolicy
     set_index_ivars
-    # @examples = Example.all
   end
 
   def create
-    authorize nil, policy_class: ContactPolicy
-
     # to be moved elsewhere
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY2'])
     data = {
-      list_ids: [ SENDGRID_MARKETING_LIST_ID ],
+      list_ids: [SENDGRID_MARKETING_LIST_ID],
       contacts: [
         email: contact_params[:email],
         first_name: contact_params[:first_name],
@@ -29,15 +28,19 @@ class ContactsController < ApplicationController
       ]
     }
     response = sg.client.marketing.contacts.put(request_body: data)
-    tid = response.parsed_body.dig(:job_id)
+    tid = response.parsed_body[:job_id]
     Rails.logger.info "Added #{tid}"
 
     5.times do |index|
-      Rails.logger.info "Iteration #{index+1}"
+      Rails.logger.info "Iteration #{index + 1}"
       sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY2'])
       response = sg.client.marketing.contacts.get
       break if response.parsed_body[:result]
-        .select{|x| x[:email] == contact_params[:email] && x[:list_ids].include?(SENDGRID_MARKETING_LIST_ID) }.present?
+                       .select do |x|
+                 x[:email] == contact_params[:email] && x[:list_ids]
+               .include?(SENDGRID_MARKETING_LIST_ID)
+               end.present?
+
       sleep 1 unless Rails.env.test?
     end
 
@@ -46,44 +49,54 @@ class ContactsController < ApplicationController
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: [
-          turbo_stream.replace('flashes', partial: '/flashes', locals: { message: "Added #{response.parsed_body.dig(:job_id)}. It can take up to five minutes for the new contact to show up in this table." }),
-          turbo_stream.replace('contacts-index-bar', partial: '/contacts/index/bar', locals: { contacts_bar_state: ContactsBarState.new }),
-          turbo_stream.replace('contacts-index-table', partial: '/contacts/index/table', locals: { contacts_table_state: ContactsTableState.new(records: default_ransack) }),
+          turbo_stream.replace('flashes', partial: '/flashes',
+                                          locals: {
+                                            message: "Added #{response.parsed_body[:job_id]}. It can take up to "\
+                                                     'five minutes for the new contact to show up in this table.'
+                                          }),
+          turbo_stream.replace('contacts-index-bar', partial: '/contacts/index/bar',
+                                                     locals: { contacts_bar_state: ContactsBarState.new }),
+          turbo_stream.replace('contacts-index-table', partial: '/contacts/index/table',
+                                                       locals: { contacts_table_state:
+                                                          ContactsTableState.new(records: default_ransack) })
         ]
       end
     end
   end
 
   def refresh
-    authorize nil, policy_class: ContactPolicy
     CacheContactsJob.perform_now
-    redirect_to "/contacts"
+    redirect_to '/contacts'
   end
 
-
   private
-    # Only allow a list of trusted parameters through.
-    def contact_params
-      params.require(:contact).permit(:first_name, :last_name, :phone, :email, :ut, :nc)
-    end
 
-    def set_index_ivars
-      @contacts_table_state = ContactsTableState.new(records: default_ransack)
-      @contacts_bar_state = ContactsBarState.new
-    end
+  def authorize_contact_policy
+    authorize nil, policy_class: ContactPolicy
+  end
 
-    def default_ransack
-      ransack = Contact.ransack
-      ransack.sorts = "sendgrid_created_at desc"
-      ransack
-    end
+  # Only allow a list of trusted parameters through.
+  def contact_params
+    params.require(:contact).permit(:first_name, :last_name, :phone, :email, :ut, :nc)
+  end
 
-    def formatted_investing_location
-      arr = []
-      arr << 'UT' if contact_params[:ut] == "1"
-      arr << 'NC' if contact_params[:nc] == "1"
-      str = arr.join('-')
-      str = "-#{str}-" if str.present?
-      str
-    end
+  def set_index_ivars
+    @contacts_table_state = ContactsTableState.new(records: default_ransack)
+    @contacts_bar_state = ContactsBarState.new
+  end
+
+  def default_ransack
+    ransack = Contact.ransack
+    ransack.sorts = 'sendgrid_created_at desc'
+    ransack
+  end
+
+  def formatted_investing_location
+    arr = []
+    arr << 'UT' if contact_params[:ut] == '1'
+    arr << 'NC' if contact_params[:nc] == '1'
+    str = arr.join('-')
+    str = "-#{str}-" if str.present?
+    str
+  end
 end


### PR DESCRIPTION
There are still 2 offenses in the contacts class for the create class:
Metrics/AbcSize and Metrics/MethodLength