### PR TITLE
Rubocop warnings for dispositions prepare listing panes controller

### DIFF
--- a/app/controllers/dispositions_prepare_listing_panes_controller.rb
+++ b/app/controllers/dispositions_prepare_listing_panes_controller.rb
@@ -13,7 +13,9 @@ class DispositionsPrepareListingPanesController < ApplicationController
       format.turbo_stream do
         render turbo_stream: [
           turbo_stream.replace('flashes', partial: '/flashes', locals: { message: resource_updates }),
-          turbo_stream.replace('dispositions_prepare_listing_pane', partial: '/dispositions_prepare_listing_pane/dispositions_prepare_listing_pane', locals: { project: @project.id })
+          turbo_stream.replace('dispositions_prepare_listing_pane',
+                               partial: '/dispositions_prepare_listing_pane/dispositions_prepare_listing_pane',
+                               locals: { project: @project.id })
         ]
       end
     end
@@ -32,6 +34,7 @@ class DispositionsPrepareListingPanesController < ApplicationController
     listing.errors.full_messages.join(', ').presence || 'Updated'
   end
 
+  # rubocop:disable Metrics/MethodLength
   # Only allow a list of trusted parameters through.
   def dispositions_prepare_listing_pane_params
     params.require(:dispositions_prepare_listing_pane).permit(
@@ -66,4 +69,5 @@ class DispositionsPrepareListingPanesController < ApplicationController
       :listed
     )
   end
+  # rubocop:enable Metrics/MethodLength
 end


### PR DESCRIPTION
For dispositions_prepare_listing_pane_params I disabled Metrics/MethodLength because youre only do it here for better reading. I can in this case remove the rubocop disabling and make the method in less lines but for readability I personally think this is a better option.